### PR TITLE
feat(changelog-types): added `inputs.changelog-types`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -70,7 +70,11 @@ runs:
         token: ${{ inputs.github-token }}
         release-type: node
         package-name: ${{ steps.package.outputs.name }}
-        changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"perf","section":"Performance Improvements","hidden":false}]'
+        changelog-types: >
+          [{"type":"feat","section":"Features","hidden":false},
+          {"type":"fix","section":"Bug Fixes","hidden":false},
+          {"type":"refactor","section":"Code Refactoring","hidden":false},
+          {"type":"perf","section":"Performance Improvements","hidden":false}]
         bump-minor-pre-major: true
         default-branch: ${{ inputs.default-branch }}
         prerelease: ${{ inputs.prerelease }}

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,13 @@ inputs:
   npm-preid:
     description:  npm version prerelease identifier, e.g preid=alpha gives you npm package version as v1.1.1-alpha.0
     required: false
+  changelog-types:
+    description: a changelog type's job is to build the CHANGELOG notes given a list of parsed commits
+    required: false
+    default: >
+      [{"type":"feat","section":"Features","hidden":false},
+      {"type":"fix","section":"Bug Fixes","hidden":false},
+      {"type":"perf","section":"Performance Improvements","hidden":false}]
 
 outputs:
   release-created:
@@ -70,11 +77,7 @@ runs:
         token: ${{ inputs.github-token }}
         release-type: node
         package-name: ${{ steps.package.outputs.name }}
-        changelog-types: >
-          [{"type":"feat","section":"Features","hidden":false},
-          {"type":"fix","section":"Bug Fixes","hidden":false},
-          {"type":"refactor","section":"Code Refactoring","hidden":false},
-          {"type":"perf","section":"Performance Improvements","hidden":false}]
+        changelog-types: ${{ inputs.changelog-types }}
         bump-minor-pre-major: true
         default-branch: ${{ inputs.default-branch }}
         prerelease: ${{ inputs.prerelease }}


### PR DESCRIPTION
Previously, [specific entry types](https://github.com/gravity-ui/release-action/commit/ccb09d74f9889c9b8ed3905f75963392aacb2eb0#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R45) were added to the changelog. The standard list also includes other [prefixes](https://github.com/googleapis/release-please/blob/main/src/changelog-notes.ts#L42). In addition to `feat`, `fix`, and `perf`, `refactor` is an important type for inclusion in the changelog.

I propose adding this entry type.