### PR TITLE
feat!: remove default node version 14

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -61,8 +61,8 @@ runs:
         echo "${{ inputs.node-version }}"
         echo "${{ inputs.node-version-file }}"
       shell: bash
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@v5
+    - uses: actions/setup-node@v6
       with:
         node-version-file: ${{ inputs.node-version-file }}
         node-version: ${{ inputs.node-version }}
@@ -74,7 +74,7 @@ runs:
     - uses: codex-team/action-nodejs-package-info@v1
       if: inputs.npm-version == ''
       id: package
-    - uses: google-github-actions/release-please-action@v3
+    - uses: google-github-actions/release-please-action@v4
       if: inputs.npm-version == ''
       id: release
       with:

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,6 @@ inputs:
   node-version:
     description: Node.js version used for running linters, tests, etc
     required: false
-    default: '14'
   github-token:
     description: PAT of a GitHub user which creates release PR
     required: true

--- a/action.yml
+++ b/action.yml
@@ -74,7 +74,7 @@ runs:
     - uses: codex-team/action-nodejs-package-info@v1
       if: inputs.npm-version == ''
       id: package
-    - uses: google-github-actions/release-please-action@v4
+    - uses: google-github-actions/release-please-action@v3
       if: inputs.npm-version == ''
       id: release
       with:


### PR DESCRIPTION
Problem: `node-version-file` rewrited by default `node-version` 14
Reason: `node-version` has priority over `node-version-file`, so it wouldn't work until default value exists
Solution: remove default value of the `node-version` and bump major version of the action